### PR TITLE
Adjust signatures to upstream

### DIFF
--- a/src/null-writable.ts
+++ b/src/null-writable.ts
@@ -3,10 +3,10 @@
 import {Writable} from "node:stream"
 
 export class NullWritable extends Writable {
-  _write(_chunk: any, _encoding: string, callback: (error?: Error | null) => void): void {
+  _write(_chunk: any, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
     callback()
   }
-  _writev(_chunks: Array<{chunk: any; encoding: string}>, callback: (error?: Error | null) => void): void {
+  _writev?(_chunks: Array<{chunk: any; encoding: BufferEncoding}>, callback: (error?: Error | null) => void): void {
     callback()
   }
 }


### PR DESCRIPTION
Adjusted the signatures slightly to match those of https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d76cf25/types/node/stream.d.ts#L724-L731
This is important for some consumers of the typings.
For example when you use Karakum to generate Kotlin code from TypeScript Type definitions.
